### PR TITLE
Quiesce Java9+ module warnings about reflective access

### DIFF
--- a/src/main/kotlin/BUILD
+++ b/src/main/kotlin/BUILD
@@ -46,5 +46,11 @@ java_binary(
     data = [":compiler_lib.jar"],
     main_class = "io.bazel.kotlin.builder.KotlinBuilderMain",
     runtime_deps = [":builder_jar_jar"],
+    jvm_flags = [
+        "-XX:+IgnoreUnrecognizedVMOptions",
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=jdk.jdeps/com.sun.tools.jdeps=ALL-UNNAMED",
+    ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
These are explicitly permitted usages so flag them as such.  Also make sure older JVMs just ignore these options if they don't know about them.