### PR TITLE
Early version of support for kotlin android extensions support.

### DIFF
--- a/kotlin/internal/repositories/BUILD.com_github_jetbrains_kotlin
+++ b/kotlin/internal/repositories/BUILD.com_github_jetbrains_kotlin
@@ -28,6 +28,12 @@ kt_jvm_import(
     neverlink = 1,
 )
 
+kt_jvm_import(
+    name = "android-extensions-compiler",
+    jars = ["lib/android-extensions-compiler.jar"],
+    neverlink = 1,
+)
+
 # Kotlin dependencies that are internal to this repo and are meant to be loaded manually into a classloader.
 [
     kt_jvm_import(

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -126,6 +126,7 @@ _kt_toolchain = rule(
             doc = "The jvm stdlibs. This is internal.",
             default = [
                 Label("@" + _KT_COMPILER_REPO + "//:annotations"),
+                Label("@" + _KT_COMPILER_REPO + "//:android-extensions-compiler"),
                 Label("@" + _KT_COMPILER_REPO + "//:kotlin-stdlib"),
                 Label("@" + _KT_COMPILER_REPO + "//:kotlin-stdlib-jdk7"),
                 # JDK8 is being added blindly but I think we will probably not support bytecode levels 1.6 when the

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -173,6 +173,14 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
         getCommonArgs().let { args ->
             args.addAll(inputs.javaSourcesList)
             args.addAll(inputs.kotlinSourcesList)
+            if ( inputs.classpathList.any { classpath -> "kotlin-android-extensions-runtime" in classpath } ) {
+                inputs.classpathList.firstOrNull { classpath -> "android-extensions-compiler" in classpath }
+                    ?.let { compiler ->
+                        args += "-Xplugin=$compiler"
+                        args += "-P"
+                        args += "plugin:org.jetbrains.kotlin.android:experimental=true"
+                    }
+            }
             context.executeCompilerTask(args, compiler::compile, printOnFail = printOnFail)
         }
 


### PR DESCRIPTION
Early and naive (but working) version of support for kotlin android extensions compiler (specifically parcelable)
   
More information about extensions is available here: https://kotlinlang.org/docs/tutorials/android-plugin.html

In newer versions of Kotlin (1.3.50) this support should be present by default, but in other versions (specifically tested on 1.3.31) this support has to be enabled by experimental flag and extra plugin.