### PR TITLE
Fix android friend declarations

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -37,6 +37,7 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], friend = None
         deps = base_deps + [base_name],
         plugins = plugins,
         testonly = kwargs.get("testonly", default = 0),
+        friend = friend,
         # must be public to be referenced as friends.
         # TODO: rework this into a proper android provider giving rule, so we can avoid all this.
         visibility = ["//visibility:public"],


### PR DESCRIPTION
The friend attribute was not passed through to the underlying _kt compilation in `kt_android_library` in #37.  Somehow it got reverted during the last review.  This PR fixes it.  The error occurred because there is no android kotlin example to force these code paths.

I would add one here but have such an example in a separate PR I'm working on to fix a regression.

Tested: applied to square's android repo.