### PR TITLE
Fix jdeps building

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
@@ -54,8 +54,8 @@ internal class JDepsGenerator @Inject constructor(
                         val version = System.getProperty("java.version").majorJavaVersion()
                         val multiRelease =
                             if (version < 9) arrayOf() else arrayOf("--multi-release", "base")
-                        val jdepsPath = command.outputs.jdeps
-                        val args = multiRelease + arrayOf("-cp", joinedClasspath, jdepsPath)
+                        val jarPath = command.outputs.jar
+                        val args = multiRelease + arrayOf("-v", "-cp", joinedClasspath, jarPath)
                         val res = invoker.run(args, writer)
                         out.toByteArray().inputStream().bufferedReader().readLines().let {
                             if (res != 0) {
@@ -63,7 +63,7 @@ internal class JDepsGenerator @Inject constructor(
                             } else try {
                                 JdepsParser.parse(
                                     command.info.label,
-                                    command.outputs.jdeps,
+                                    jarPath,
                                     command.inputs.classpathList,
                                     it,
                                     isKotlinImplicit

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
@@ -112,12 +112,12 @@ internal class JdepsParser private constructor(private val filename: String, pri
 
         fun parse(
             label: String,
-            classJar: String,
+            jarFile: String,
             classPath: MutableList<String>,
             lines: List<String>,
             isImplicit: Predicate<String>
         ): Deps.Dependencies {
-            val filename = Paths.get(classJar).fileName.toString()
+            val filename = Paths.get(jarFile).fileName.toString()
             val jdepsParser = JdepsParser(filename, isImplicit)
             classPath.forEach { x -> jdepsParser.consumeJarLine(x, Deps.Dependency.Kind.UNUSED) }
             lines.forEach { jdepsParser.processLine(it) }


### PR DESCRIPTION
.jdeps files were not being created correctly such that IntelliJ could correctly identify the external libraries.